### PR TITLE
Removed color declaration

### DIFF
--- a/stylesheets/grid.scss
+++ b/stylesheets/grid.scss
@@ -78,7 +78,6 @@ html, body, div, span, applet, object, iframe, p, blockquote, pre, a, abbr, acro
 }
 
 html {
-    color: #333;
     font: $font-size sans-serif;
     -webkit-font-size-adjust: 100%;
 }


### PR DESCRIPTION
Om het grid nog meer lightweight te maken is het niet nodig om een color aan de background toe te voegen. Dit wordt op andere plekken ook niet gedaan (bijvoorbeeld voor het font) dus ik vraag me af waarom het hier wel gedaan wordt.
